### PR TITLE
Update registration module to 1.8.x support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 **/ Registration Module FREE Version \**
-**/ Module by Mubeen & Gigabait for Pterodactyl 1.4.x \**
+**/ Module by Mubeen & Gigabait for Pterodactyl 1.8.x \**
 
 Before proceeding with installation make sure you have checked the following things:
 
-* Make sure you're running the latest version of Pterodactyl
+* Make sure you're running version 1.8.x of Pterodactyl
 * This Module works with the Unix theme, please contact Mubeen to get the files for the theme.
 
 Installation:

--- a/Registration Module Files/app/Http/Controllers/Auth/RegisterController.php
+++ b/Registration Module Files/app/Http/Controllers/Auth/RegisterController.php
@@ -5,6 +5,7 @@ namespace Pterodactyl\Http\Controllers\auth;
 use Pterodactyl\Contracts\Repository\LocationRepositoryInterface;
 use Pterodactyl\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class RegisterController extends Controller
 {
@@ -29,14 +30,14 @@ class RegisterController extends Controller
 	 *
 	 * @return \Illuminate\View\View
 	 */
-	public function index()
+	public function index(): View
 	{
 		return view('templates/auth.register', [
 			'locations' => $this->repository->getAllWithDetails(),
 		]);
 	}
 
-	public function register(Request $req)
+	public function register(Request $req): View
 	{
 		$valid = $req->validate([
 			'registration_email' => 'required|email|regex:/(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)+/|min:5|max:35',

--- a/Registration Module Files/app/Providers/RouteServiceProvider.php
+++ b/Registration Module Files/app/Providers/RouteServiceProvider.php
@@ -3,21 +3,18 @@
 namespace Pterodactyl\Providers;
 
 use Illuminate\Http\Request;
+use Pterodactyl\Models\Database;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Support\Facades\RateLimiter;
+use Pterodactyl\Http\Middleware\TrimStrings;
+use Pterodactyl\Http\Middleware\AdminAuthenticate;
+use Pterodactyl\Http\Middleware\RequireTwoFactorAuthentication;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
 class RouteServiceProvider extends ServiceProvider
 {
-    /**
-     * This namespace is applied to the controller routes in your routes file.
-     *
-     * In addition, it is set as the URL generator's root namespace.
-     *
-     * @var string
-     */
-    protected $namespace = 'Pterodactyl\Http\Controllers';
+    protected const FILE_PATH_REGEX = '/^\/api\/client\/servers\/([a-z0-9-]{36})\/files(\/?$|\/(.)*$)/i';
 
     /**
      * Define your route model bindings, pattern filters, etc.
@@ -26,36 +23,44 @@ class RouteServiceProvider extends ServiceProvider
     {
         $this->configureRateLimiting();
 
+        // Disable trimming string values when requesting file information — it isn't helpful
+        // and messes up the ability to actually open a directory that ends with a space.
+        TrimStrings::skipWhen(function (Request $request) {
+            return preg_match(self::FILE_PATH_REGEX, $request->getPathInfo()) === 1;
+        });
+
+        // This is needed to make use of the "resolveRouteBinding" functionality in the
+        // model. Without it you'll never trigger that logic flow thus resulting in a 404
+        // error because we request databases with a HashID, and not with a normal ID.
+        Route::model('database', Database::class);
+
         $this->routes(function () {
-            Route::middleware(['web', 'auth', 'csrf'])
-                ->namespace("$this->namespace\\Base")
-                ->group(base_path('routes/base.php'));
+            Route::middleware('web')->group(function () {
+                Route::middleware(['auth.session', RequireTwoFactorAuthentication::class])
+                    ->group(base_path('routes/base.php'));
 
-            Route::middleware(['web', 'auth', 'admin', 'csrf'])->prefix('/admin')
-                ->namespace("$this->namespace\\Admin")
-                ->group(base_path('routes/admin.php'));
+                Route::middleware(['auth.session', RequireTwoFactorAuthentication::class, AdminAuthenticate::class])
+                    ->prefix('/admin')
+                    ->group(base_path('routes/admin.php'));
 
-            Route::middleware(['web', 'csrf'])->prefix('/auth')
-                ->namespace("$this->namespace\\Auth")
-                ->group(base_path('routes/auth.php'));
+                Route::middleware('guest')->prefix('/auth')->group(base_path('routes/auth.php'));
+            });
 
-            Route::middleware(['web', 'csrf', 'auth', 'server', 'node.maintenance'])
-                ->prefix('/api/server/{server}')
-                ->namespace("$this->namespace\\Server")
-                ->group(base_path('routes/server.php'));
+            Route::middleware(['api', RequireTwoFactorAuthentication::class])->group(function () {
+                Route::middleware(['application-api', 'throttle:api.application'])
+                    ->prefix('/api/application')
+                    ->scopeBindings()
+                    ->group(base_path('routes/api-application.php'));
 
-            Route::middleware(['api', 'throttle:api.application'])
-                ->prefix('/api/application')
-                ->namespace("$this->namespace\\Api\\Application")
-                ->group(base_path('routes/api-application.php'));
+                Route::middleware(['client-api', 'throttle:api.client'])
+                    ->prefix('/api/client')
+                    ->scopeBindings()
+                    ->group(base_path('routes/api-client.php'));
+            });
 
-            Route::middleware(['client-api', 'throttle:api.client'])
-                ->prefix('/api/client')
-                ->namespace("$this->namespace\\Api\\Client")
-                ->group(base_path('routes/api-client.php'));
-
-            Route::middleware(['daemon'])->prefix('/api/remote')
-                ->namespace("$this->namespace\\Api\\Remote")
+            Route::middleware('daemon')
+                ->prefix('/api/remote')
+                ->scopeBindings()
                 ->group(base_path('routes/api-remote.php'));
 
             /**

--- a/Registration Module Files/routes/register_module.php
+++ b/Registration Module Files/routes/register_module.php
@@ -1,13 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Pterodactyl\Http\Controllers\Auth\RegisterController;
+use Pterodactyl\Http\Controllers\Auth\LoginController;
 
 
 Route::group(['middleware' => 'guest'], function () {
 
-	Route::get('/register', 'RegisterController@index')->name('auth.register');
-	Route::post('/register/user', 'RegisterController@register')->name('auth.register.url');
+	Route::get('/register', [RegisterController::class, 'index'])->name('auth.register');
+	Route::post('/register/user', [RegisterController::class, 'register'])->name('auth.register.url');
 });
-
-
-Route::get('/logout', 'LoginController@logout')->name('auth.logout')->middleware('auth');


### PR DESCRIPTION
I've tested the code changes and I haven't received any issues yet. This should allow pterodactyl 1.8.0 and 1.8.1 users to be able to use this module again.

If anyone wants to test, feel free to do so.

+ I'm pretty sure removing the /logout route works, since I'm seeing logout internally in a route file in pterodactyl 1.8.